### PR TITLE
Restructure index page with coaching syllabus and add mobile search FAB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out/
 # Build
 build/
 dist/
+*.tsbuildinfo
 
 # Environment
 .env

--- a/app/[locale]/blog/page.tsx
+++ b/app/[locale]/blog/page.tsx
@@ -28,8 +28,8 @@ export default async function BlogPage({
   const { locale } = await params;
   setRequestLocale(locale);
   const t = await getTranslations("BLOG");
-  const posts = getAllPosts();
-  const tags = getAllTags();
+  const posts = getAllPosts(locale);
+  const tags = getAllTags(locale);
 
   return (
     <>

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -86,7 +86,7 @@ export default async function LocaleLayout({
     };
   });
 
-  const blogPosts = getAllPosts();
+  const blogPosts = getAllPosts(locale);
 
   const searchItems: SearchableItem[] = [
     ...weeks.map((w) => {

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { Link } from "@/lib/i18n/navigation";
 import { getAllPosts } from "@/lib/markdown";
-import { getWeeks, getLessons, getHabits } from "@/lib/contentful";
+import { getWeeks } from "@/lib/contentful";
 import {
   generatePageMetadata,
   generateOrganizationJsonLd,
@@ -10,9 +10,6 @@ import {
 import AnimateOnScroll from "@/components/AnimateOnScroll";
 import BlogPostCard from "@/components/BlogPostCard";
 import NewsletterForm from "@/components/NewsletterForm";
-import WeekCard from "@/components/WeekCard";
-import LessonCard from "@/components/LessonCard";
-import HabitCard from "@/components/HabitCard";
 
 export async function generateMetadata({
   params,
@@ -41,11 +38,7 @@ export default async function HomePage({
   const tCoaching = await getTranslations("COACHING");
   const tBlog = await getTranslations();
   const posts = getAllPosts().slice(0, 3);
-  const [weeks, lessons, habits] = await Promise.all([
-    getWeeks(locale),
-    getLessons(locale),
-    getHabits(locale),
-  ]);
+  const weeks = await getWeeks(locale);
 
   return (
     <>
@@ -131,88 +124,102 @@ export default async function HomePage({
         </div>
       </section>
 
-      {/* Coaching Weeks */}
+      {/* Coaching Program — Syllabus */}
       {weeks.length > 0 && (
-        <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+        <section className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
           <AnimateOnScroll>
             <div className="text-center mb-14">
               <h2 className="text-3xl sm:text-4xl font-serif font-semibold text-brand-deep mb-4">
-                {tCoaching("WEEKS")}
+                {t("COACHING_PROGRAM")}
               </h2>
               <p className="text-lg text-text-secondary max-w-2xl mx-auto">
                 {tCoaching("WEEKS_TEXT")}
               </p>
             </div>
           </AnimateOnScroll>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
-            {weeks.slice(0, 4).map((week, i) => (
-              <WeekCard
-                key={week.sys.id}
-                week={week}
-                index={i}
-                weekLabel={tBlog("WEEK_NUMBER", { order: Number(week.fields.order) })}
-              />
-            ))}
-          </div>
-        </section>
-      )}
 
-      {/* Lessons Preview */}
-      {lessons.length > 0 && (
-        <section className="bg-bg-cream py-24">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <AnimateOnScroll>
-              <div className="text-center mb-14">
-                <h2 className="text-3xl sm:text-4xl font-serif font-semibold text-brand-deep mb-4">
-                  {tCoaching("LESSONS")}
-                </h2>
-                <p className="text-lg text-text-secondary max-w-2xl mx-auto">
-                  {tCoaching("LESSONS_TEXT")}
-                </p>
-              </div>
-            </AnimateOnScroll>
-            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
-              {lessons.slice(0, 6).map((lesson, i) => (
-                <LessonCard key={lesson.sys.id} lesson={lesson} index={i} />
-              ))}
-            </div>
-            <div className="text-center mt-12">
-              <Link
-                href="/coaching#lessons"
-                className="inline-flex items-center px-7 py-3.5 border border-brand-blue text-brand-blue font-semibold rounded-full no-underline hover:bg-brand-blue hover:text-white transition-all"
-              >
-                {tCoaching("LESSONS_TEXT")} &rarr;
-              </Link>
-            </div>
-          </div>
-        </section>
-      )}
+          <div className="space-y-8">
+            {weeks.map((week, wi) => {
+              const wf = week.fields as Record<string, unknown>;
+              const lessons = (wf.lessons as Array<{ sys: { id: string }; fields: Record<string, unknown> }>) || [];
 
-      {/* Habits Preview */}
-      {habits.length > 0 && (
-        <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
-          <AnimateOnScroll>
-            <div className="text-center mb-14">
-              <h2 className="text-3xl sm:text-4xl font-serif font-semibold text-brand-deep mb-4">
-                {tCoaching("HABITS")}
-              </h2>
-              <p className="text-lg text-text-secondary max-w-2xl mx-auto">
-                {tCoaching("HABITS_TEXT")}
-              </p>
-            </div>
-          </AnimateOnScroll>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
-            {habits.slice(0, 6).map((habit, i) => (
-              <HabitCard key={habit.sys.id} habit={habit} index={i} />
-            ))}
-          </div>
-          <div className="text-center mt-12">
-            <Link
-              href="/coaching#habits"
-              className="inline-flex items-center px-7 py-3.5 border border-brand-blue text-brand-blue font-semibold rounded-full no-underline hover:bg-brand-blue hover:text-white transition-all"
-            >
-              {tCoaching("HABITS_TEXT")} &rarr;
-            </Link>
+              return (
+                <AnimateOnScroll key={week.sys.id} delay={wi * 80}>
+                  <div className="bg-white rounded-2xl border border-hairline p-6 sm:p-8">
+                    {/* Week heading */}
+                    <Link
+                      href={`/coaching/weeks/${String(wf.slug)}`}
+                      className="group block no-underline"
+                    >
+                      <div className="flex items-baseline gap-3 mb-1">
+                        <span className="text-sm font-semibold text-brand-blue">
+                          {tBlog("WEEK_NUMBER", { order: Number(wf.order) })}
+                        </span>
+                      </div>
+                      <h3 className="text-xl sm:text-2xl font-serif font-semibold text-brand-deep group-hover:text-brand-blue transition-colors">
+                        {String(wf.weekName)} &rarr;
+                      </h3>
+                      {typeof wf.intro === "string" && wf.intro && (
+                        <p className="text-text-secondary mt-2 leading-relaxed">
+                          {wf.intro}
+                        </p>
+                      )}
+                    </Link>
+
+                    {/* Lessons under this week */}
+                    {lessons.length > 0 && (
+                      <div className="mt-6 space-y-4">
+                        {lessons.map((lesson) => {
+                          const lf = lesson.fields;
+                          if (!lf) return null;
+                          const habits = (lf.habit as Array<{ sys: { id: string }; fields: Record<string, unknown> }>) || [];
+
+                          return (
+                            <div key={lesson.sys.id} className="pl-4 border-l-2 border-brand-blue/15">
+                              <Link
+                                href={`/coaching/lessons/${String(lf.slug)}`}
+                                className="group/lesson inline-flex items-center gap-2 no-underline"
+                              >
+                                <span className="text-base font-medium text-text-primary group-hover/lesson:text-brand-blue transition-colors">
+                                  {String(lf.lessonName)}
+                                </span>
+                              </Link>
+
+                              {/* Habits under this lesson */}
+                              {habits.length > 0 && (
+                                <div className="flex flex-wrap gap-1.5 mt-2">
+                                  {habits.map((habit) => {
+                                    const hf = habit.fields;
+                                    if (!hf) return null;
+                                    const period = String(hf.period || "").toUpperCase();
+                                    const periodColor =
+                                      period === "MORNING"
+                                        ? "bg-amber-50 text-amber-700 border-amber-200"
+                                        : period === "EVENING"
+                                          ? "bg-indigo-50 text-indigo-700 border-indigo-200"
+                                          : "bg-emerald-50 text-emerald-700 border-emerald-200";
+
+                                    return (
+                                      <Link
+                                        key={habit.sys.id}
+                                        href={`/coaching/habits/${String(hf.slug)}`}
+                                        className={`inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-full border no-underline hover:shadow-sm transition-shadow ${periodColor}`}
+                                      >
+                                        {String(hf.title)}
+                                      </Link>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </AnimateOnScroll>
+              );
+            })}
           </div>
         </section>
       )}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -37,7 +37,7 @@ export default async function HomePage({
   const t = await getTranslations("INDEX");
   const tCoaching = await getTranslations("COACHING");
   const tBlog = await getTranslations();
-  const posts = getAllPosts().slice(0, 3);
+  const posts = getAllPosts(locale).slice(0, 3);
   const weeks = await getWeeks(locale);
 
   return (

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -99,6 +99,17 @@ export default function CommandPalette({
   const categoryOrder = ["week", "lesson", "habit", "questionnaire", "author", "blog"];
 
   return (
+    <>
+    {/* Mobile floating search button */}
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      className="fixed bottom-6 right-6 z-40 lg:hidden flex items-center justify-center w-14 h-14 rounded-full bg-brand-blue text-white shadow-lg hover:shadow-xl active:scale-95 transition-all"
+      aria-label={t("PLACEHOLDER")}
+    >
+      <MagnifyingGlassIcon className="size-6" />
+    </button>
+
     <Dialog
       className="relative z-50"
       open={open}
@@ -205,5 +216,6 @@ export default function CommandPalette({
         </DialogPanel>
       </div>
     </Dialog>
+    </>
   );
 }

--- a/content/blog/6-tips-for-better-sleep/index.md
+++ b/content/blog/6-tips-for-better-sleep/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "6-tips-for-better-sleep"
+lang: "en"
 date: "2020-04-28"
 title: "The 6 Things You Need for Good Sleep"
 author: "Perttu Lähteenlahti"

--- a/content/blog/6-vinkkia-parempaan-uneen/index.md
+++ b/content/blog/6-vinkkia-parempaan-uneen/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "6-vinkkia-parempaan-uneen"
+lang: "fi"
 date: "2020-04-28"
 title: "6 asiaa, jotka tarvitset hyvään uneen"
 author: "Perttu Lähteenlahti"

--- a/content/blog/avain-luovuuteen-uni/index.md
+++ b/content/blog/avain-luovuuteen-uni/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "avain-luovuuteen-uni"
+lang: "fi"
 date: "2018-05-07"
 title: "Avain luovuuteen: uni"
 authorSlug: "perttu-lahteenlahti"

--- a/content/blog/can-sleep-debt-be-paid-off/index.md
+++ b/content/blog/can-sleep-debt-be-paid-off/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "can-sleep-debt-be-paid-off"
+lang: "en"
 date: "2020-04-06"
 title: "Can Sleep Debt Be Paid Off?"
 authorSlug: "anu-katriina-pesonen"

--- a/content/blog/consistency-is-key-are-you-unknowingly-suffering-from-social-jet-lag/index.md
+++ b/content/blog/consistency-is-key-are-you-unknowingly-suffering-from-social-jet-lag/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "consistency-is-key-are-you-unknowingly-suffering-from-social-jet-lag"
+lang: "en"
 date: "2019-10-20"
 title: Consistency is Key – Are You Unknowingly Suffering from Social Jet Lag?
 authorSlug: "eeva-siika-aho"

--- a/content/blog/estimating-the-sleep-wake-cycle-through-circadian-rhythm/index.md
+++ b/content/blog/estimating-the-sleep-wake-cycle-through-circadian-rhythm/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "estimating-the-sleep-wake-cycle-through-circadian-rhythm"
+lang: "en"
 date: "2020-09-28"
 title: "Estimating the Sleep-Wake Cycle Through Circadian Rhythm"
 authorSlug: "miska-nurmi"

--- a/content/blog/getting-high-and-getting-sleep/index.md
+++ b/content/blog/getting-high-and-getting-sleep/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "getting-high-and-getting-sleep"
+lang: "en"
 date: "2020-09-07"
 title: Getting High and Getting Sleep
 authorSlug: "liisa-kuula"

--- a/content/blog/heart-rate-variability-hrv-is-the-hype-justified/index.md
+++ b/content/blog/heart-rate-variability-hrv-is-the-hype-justified/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "heart-rate-variability-hrv-is-the-hype-justified"
+lang: "en"
 date: "2020-08-24"
 title: Heart Rate Variability (HRV) – Is the Hype Justified?
 authorSlug: "pietari-nurmi"

--- a/content/blog/how-to-use-sleep-for-your-success/index.md
+++ b/content/blog/how-to-use-sleep-for-your-success/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "how-to-use-sleep-for-your-success"
+lang: "en"
 date: "2020-10-02"
 title: How to Use Sleep for Your Success
 authorSlug: "pietari-nurmi"

--- a/content/blog/kannabis-ja-uni/index.md
+++ b/content/blog/kannabis-ja-uni/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "kannabis-ja-uni"
+lang: "fi"
 date: "2020-09-07"
 title: "Kannabis ja uni"
 authorSlug: "liisa-kuula"

--- a/content/blog/key-to-unlocking-creativity-sleep/index.md
+++ b/content/blog/key-to-unlocking-creativity-sleep/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "key-to-unlocking-creativity-sleep"
+lang: "en"
 date: "2018-05-07"
 title: "Key to Unlocking Creativity: Sleep"
 authorSlug: "perttu-lahteenlahti"

--- a/content/blog/kohti-parempaa-unta-terveystalo-nyxo/index.md
+++ b/content/blog/kohti-parempaa-unta-terveystalo-nyxo/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "kohti-parempaa-unta-terveystalo-nyxo"
+lang: "fi"
 date: "2019-10-20"
 title: "Kohti parempaa unta Terveystalon ja Nyxon kanssa"
 authorSlug: "eeva-siika-aho"

--- a/content/blog/lyhyt-uni-lihottaa/index.md
+++ b/content/blog/lyhyt-uni-lihottaa/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "lyhyt-uni-lihottaa"
+lang: "fi"
 date: "2020-08-19"
 title: "Lyhyet younet voivat johtaa painonnousuun"
 authorSlug: "perttu-lahteenlahti"

--- a/content/blog/miksi-uni-ei-virkista-suomeksi/index.md
+++ b/content/blog/miksi-uni-ei-virkista-suomeksi/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "miksi-uni-ei-virkista-suomeksi"
+lang: "fi"
 date: "2020-04-30"
 title: "Miksi uni ei virkistä?"
 authorSlug: "pietari-nurmi"

--- a/content/blog/miksi-uni-ei-virkista/index.md
+++ b/content/blog/miksi-uni-ei-virkista/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "why-doesnt-sleep-refresh-you"
+lang: "en"
 date: "2020-04-30"
 title: "Why Doesn't Sleep Refresh You?"
 authorSlug: "pietari-nurmi"

--- a/content/blog/mita-syke-kertoo-unestasi/index.md
+++ b/content/blog/mita-syke-kertoo-unestasi/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "mita-syke-kertoo-unestasi"
+lang: "fi"
 date: "2020-08-17"
 title: "Mitä syke kertoo unestasi"
 authorSlug: "pietari-nurmi"

--- a/content/blog/nba-oura-ring/index.md
+++ b/content/blog/nba-oura-ring/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "nba-oura-ring"
+lang: "en"
 date: "2020-07-14"
 title: "NBA Bought 2000 Oura Rings, and This Is Why It's the Best Thing for Sports Ever"
 authorSlug: "pietari-nurmi"

--- a/content/blog/nba-oura-sormus/index.md
+++ b/content/blog/nba-oura-sormus/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "nba-oura-sormus"
+lang: "fi"
 date: "2020-07-14"
 title: "NBA osti 2000 Oura-sormusta -- ja siksi se on parasta mitä urheilulle on tapahtunut"
 authorSlug: "pietari-nurmi"

--- a/content/blog/sailyyko-uni-tasaisena-karsitko-sosiaalisesta-jet-lagista/index.md
+++ b/content/blog/sailyyko-uni-tasaisena-karsitko-sosiaalisesta-jet-lagista/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "sailyyko-uni-tasaisena-karsitko-sosiaalisesta-jet-lagista"
+lang: "fi"
 date: "2019-10-20"
 title: "Säilyykö uni tasaisena -- kärsitkö sosiaalisesta jet lagista?"
 authorSlug: "eeva-siika-aho"

--- a/content/blog/short-sleep-can-lead-to-weight-gain/index.md
+++ b/content/blog/short-sleep-can-lead-to-weight-gain/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "short-sleep-can-lead-to-weight-gain"
+lang: "en"
 date: "2020-08-19"
 title: Short Sleep Can Lead to Weight Gain
 authorSlug: "perttu-lahteenlahti"

--- a/content/blog/sleep-tracker-buyers-guide-pt1/index.md
+++ b/content/blog/sleep-tracker-buyers-guide-pt1/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "sleep-tracker-buyers-guide-pt1"
+lang: "en"
 date: "2020-08-31"
 title: "Sleep Tracker Buyer's Guide Pt. 1: What You Should Know About Sleep Tracking"
 authorSlug: "pietari-nurmi"

--- a/content/blog/sleep-tracker-buyers-guide-pt2/index.md
+++ b/content/blog/sleep-tracker-buyers-guide-pt2/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "sleep-tracker-buyers-guide-pt2"
+lang: "en"
 date: "2020-09-01"
 title: "Sleep Tracker Buyer's Guide Pt. 2: How to Choose the Best Tracker for You"
 authorSlug: "pietari-nurmi"

--- a/content/blog/sykevaihtelun-hyoty/index.md
+++ b/content/blog/sykevaihtelun-hyoty/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "sykevaihtelun-hyoty"
+lang: "fi"
 date: "2020-08-24"
 title: "Sykevaihtelun mittaaminen (HRV) -- onko hype perusteltua?"
 authorSlug: "pietari-nurmi"

--- a/content/blog/towards-better-slumber-with-terveystalo-nyxo/index.md
+++ b/content/blog/towards-better-slumber-with-terveystalo-nyxo/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "towards-better-slumber-with-terveystalo-nyxo"
+lang: "en"
 date: "2019-10-20"
 title: Towards Better Slumber with Terveystalo & Nyxo
 authorSlug: "eeva-siika-aho"

--- a/content/blog/uni-menestyksen-valineena/index.md
+++ b/content/blog/uni-menestyksen-valineena/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "uni-menestyksen-valineena"
+lang: "fi"
 date: "2020-10-02"
 title: "Kuinka hyödyntää unta menestyksen välineenä"
 authorSlug: "pietari-nurmi"

--- a/content/blog/unimittarin-ostajan-opas-osa-1/index.md
+++ b/content/blog/unimittarin-ostajan-opas-osa-1/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "unimittarin-ostajan-opas-osa-1"
+lang: "fi"
 date: "2020-08-31"
 title: "Unimittarin ostajan opas, osa 1: Mitä sinun tulisi tietää unen seurannasta"
 authorSlug: "pietari-nurmi"

--- a/content/blog/unimittarin-ostajan-opas-osa-2/index.md
+++ b/content/blog/unimittarin-ostajan-opas-osa-2/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "unimittarin-ostajan-opas-osa-2"
+lang: "fi"
 date: "2020-09-01"
 title: "Unimittarin ostajan opas, osa 2: Miten valitset parhaan mittarin juuri sinulle"
 authorSlug: "pietari-nurmi"

--- a/content/blog/voiko-univelkaa-maksaa-takaisin/index.md
+++ b/content/blog/voiko-univelkaa-maksaa-takaisin/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "voiko-univelkaa-maksaa-takaisin"
+lang: "fi"
 date: "2020-04-06"
 title: "Voiko univelkaa maksaa takaisin?"
 authorSlug: "anu-katriina-pesonen"

--- a/content/blog/vuorokausirytmin-arviointi/index.md
+++ b/content/blog/vuorokausirytmin-arviointi/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "vuorokausirytmin-arviointi"
+lang: "fi"
 date: "2020-09-28"
 title: "Uni-valvesyklin arviointi vuorokausirytmin avulla"
 authorSlug: "miska-nurmi"

--- a/content/blog/what-can-heart-rate-tell-about-your-sleep/index.md
+++ b/content/blog/what-can-heart-rate-tell-about-your-sleep/index.md
@@ -1,5 +1,6 @@
 ---
 slug: "what-can-heart-rate-tell-about-your-sleep"
+lang: "en"
 date: "2020-08-17"
 title: What Can Heart Rate Tell About Your Sleep
 authorSlug: "pietari-nurmi"

--- a/lib/markdown.ts
+++ b/lib/markdown.ts
@@ -17,6 +17,7 @@ export interface BlogPost {
   tags: string[];
   thumbnailBlog: string;
   canonical?: string;
+  lang: string;
   content: string;
   excerpt: string;
 }
@@ -30,6 +31,7 @@ export interface BlogPostMeta {
   tags: string[];
   thumbnailBlog: string;
   canonical?: string;
+  lang: string;
   excerpt: string;
 }
 
@@ -66,7 +68,7 @@ export function getAllPostSlugs(): string[] {
     );
 }
 
-export function getAllPosts(): BlogPostMeta[] {
+export function getAllPosts(locale?: string): BlogPostMeta[] {
   const slugs = getAllPostSlugs();
 
   const posts = slugs
@@ -88,12 +90,17 @@ export function getAllPosts(): BlogPostMeta[] {
           ? resolveImagePath(data.thumbnailBlog, slug)
           : "",
         canonical: data.canonical,
+        lang: data.lang || "en",
         excerpt: generateExcerpt(content),
       } satisfies BlogPostMeta;
     })
     .filter(Boolean) as BlogPostMeta[];
 
-  return posts.sort(
+  const filtered = locale
+    ? posts.filter((p) => p.lang === locale)
+    : posts;
+
+  return filtered.sort(
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
   );
 }
@@ -131,13 +138,14 @@ export async function getPostBySlug(
       ? resolveImagePath(data.thumbnailBlog, slug)
       : "",
     canonical: data.canonical,
+    lang: data.lang || "en",
     content: processedContent.toString(),
     excerpt: generateExcerpt(content),
   };
 }
 
-export function getAllTags(): { tag: string; count: number }[] {
-  const posts = getAllPosts();
+export function getAllTags(locale?: string): { tag: string; count: number }[] {
+  const posts = getAllPosts(locale);
   const tagCount = new Map<string, number>();
 
   for (const post of posts) {

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,8 @@
     "HABITS_HEADING": "Daily Habits & Exercises",
     "HABITS_TEXT": "Put knowledge into practice with morning, afternoon, and evening habits designed to reshape your daily routine around better sleep.",
 
+    "COACHING_PROGRAM": "The Coaching Program",
+
     "ORGANIZATIONS": "Supercharge Your Organization",
     "ORGANIZATIONS_TEXT": "With Nyxo for teams (coming soon), you can enroll your team or even your whole organization into the coaching program. We will help your employees to sleep better and improve both their well-being and work performance."
   },

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -16,6 +16,8 @@
     "HABITS_HEADING": "Päivittäiset tavat ja harjoitukset",
     "HABITS_TEXT": "Vie tieto käytäntöön aamu-, iltapäivä- ja iltatavoilla, jotka on suunniteltu muokkaamaan päivärytmiäsi parempaa unta tukevaksi.",
 
+    "COACHING_PROGRAM": "Valmennusohjelma",
+
     "ORGANIZATIONS": "Valjasta tiimisi täyteen potentiaaliinsa",
     "ORGANIZATIONS_TEXT": "Tiedätkö miten teillä nukutaan? Nyxo for Teamsin (tulossa pian) avulla voit lisätä koko tiimisi mukaan univalmennukseen. Autamme työntekijöitäsi nukkumaan paremmin, lisäämään hyvinvointiaan ja kasvattamaan suorituskykyään."
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "eslint-config-next": "^16.1.6",
         "jsdom": "^28.1.0",
         "tailwindcss": "^4.0.0",
-        "typescript": "^5.7.0",
+        "typescript": "5.9.3",
         "vitest": "^4.0.18"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-config-next": "^16.1.6",
     "jsdom": "^28.1.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.7.0",
+    "typescript": "5.9.3",
     "vitest": "^4.0.18"
   }
 }


### PR DESCRIPTION
Replace separate Weeks/Lessons/Habits grid sections on the index page with
a syllabus-style view where each coaching week lists its lessons and habits
inline, giving visitors a clear overview of the program structure.

Add a floating action button (bottom-right, mobile only) that opens the
Cmd+K search panel, making it accessible on touch devices.

https://claude.ai/code/session_01Cg7TWdtVtNoPVMf8UmFf7x